### PR TITLE
Miscellaneous script cleanups

### DIFF
--- a/debug-scripts/dump-envoy-config-gwapi.sh
+++ b/debug-scripts/dump-envoy-config-gwapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 kill $(lsof -i :15000 | tail -1 | awk '{print $2}') &> /dev/null
 POD=$(oc get -n gwapi pod --no-headers | grep -i gateway | awk '{print $1}' | head -1)

--- a/debug-scripts/dump-envoy-config-istioapi.sh
+++ b/debug-scripts/dump-envoy-config-istioapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 kill $(lsof -i :15000 | tail -1 | awk '{print $2}') &> /dev/null
 
 

--- a/debug-scripts/open-envoy-webpage-gwapi.sh
+++ b/debug-scripts/open-envoy-webpage-gwapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 kill $(lsof -i :15000 | tail -1 | awk '{print $2}') &> /dev/null
 POD=$(oc get -n gwapi pod --no-headers | grep -i gateway | awk '{print $1}' | head -1)
 oc port-forward --address 127.0.0.1 -n gwapi pod/${POD} 15000:15000 &

--- a/debug-scripts/open-envoy-webpage-istioapi.sh
+++ b/debug-scripts/open-envoy-webpage-istioapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 kill $(lsof -i :15000 | tail -1 | awk '{print $2}') &> /dev/null
 POD=$(oc get -n istio-system pod --no-headers | grep istio-ingressgateway | awk '{print $1}')

--- a/helper-scripts/convert-console-route.sh
+++ b/helper-scripts/convert-console-route.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 YAML_DIR=${SCRIPT_DIR}/../yaml

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -7,6 +7,8 @@ YAML_DIR=${SCRIPT_DIR}/../yaml
 CERT_DIR=/tmp/istio-certs
 mkdir -p $CERT_DIR
 
+: "${ISTIO_BM:=""}"
+
 function create_certs() {
   TYPE="$1"
   CERT_DOMAIN="$2"

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -68,7 +68,7 @@ oc create namespace istioapi --dry-run=client -o yaml | oc apply -f -
 oc create namespace gwapi  --dry-run=client -o yaml | oc apply --overwrite=true -f -
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:istioapi
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:gwapi
-oc create -n gwapi serviceaccount istio-ingressgateway-service-account
+oc create -n gwapi serviceaccount istio-ingressgateway-service-account --dry-run=client -o yaml | oc apply -f -
 oc adm policy add-scc-to-user privileged -n gwapi -z istio-ingressgateway-service-account
 
 GWAPI_SERVICE="gateway"

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -eu
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 YAML_DIR=${SCRIPT_DIR}/../yaml
 CERT_DIR=/tmp/istio-certs
@@ -72,7 +74,7 @@ oc create -n gwapi serviceaccount istio-ingressgateway-service-account --dry-run
 oc adm policy add-scc-to-user privileged -n gwapi -z istio-ingressgateway-service-account
 
 GWAPI_SERVICE="gateway"
-if [[ "$GW_MANUAL_DEPLOYMENT" == "true" ]]; then
+if [[ "${GW_MANUAL_DEPLOYMENT:=}" == "true" ]]; then
   echo "GW_MANUAL_DEPLOYMENT is set. Using manual deployment for GWAPI"
   if [[ "$GW_HOST_NETWORKING" == "true" ]]; then
     echo "GW_HOST_NETWORKING is set. Using host networking for GWAPI"

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -eu
+set -u
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 YAML_DIR=${SCRIPT_DIR}/../yaml

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -78,7 +78,7 @@ oc adm policy add-scc-to-user privileged -n gwapi -z istio-ingressgateway-servic
 GWAPI_SERVICE="gateway"
 if [[ "${GW_MANUAL_DEPLOYMENT:=}" == "true" ]]; then
   echo "GW_MANUAL_DEPLOYMENT is set. Using manual deployment for GWAPI"
-  if [[ "$GW_HOST_NETWORKING" == "true" ]]; then
+  if [[ "${GW_HOST_NETWORKING:=}" == "true" ]]; then
     echo "GW_HOST_NETWORKING is set. Using host networking for GWAPI"
     export GW_HOST_NETWORKING_YAML=$(cat <<-END
         ports:
@@ -139,6 +139,8 @@ fi
 
 
 if [[ "$ISTIO_BM" != "true" ]]; then
+  : "${GWAPI_LOADBALANCER_DOMAIN:=""}"
+  : "${GWAPI_LOADBALANCER_IP:=""}"
   TIMEOUT=60
   while [[ "$GWAPI_LOADBALANCER_DOMAIN" == "" ]] && [[ "$GWAPI_LOADBALANCER_IP" == "" ]]; do
     # For AWS, it uses hostname, but for GCE, it uses IP

--- a/helper-scripts/create-nginx-examples.sh
+++ b/helper-scripts/create-nginx-examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 YAML_DIR=${SCRIPT_DIR}/../yaml

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu
 

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -19,7 +19,7 @@ oc adm policy add-scc-to-user privileged -n istio-system -z istio-ingressgateway
 
 if [[ ! -x "$DOWNLOAD_DIR/bin/istioctl" ]]; then
     echo "Downloading and extracting $ISTIO_RELEASE"
-    curl -Ls -o istio.tar.gz --output-dir "$DOWNLOAD_DIR" "$ISTIO_RELEASE"
+    curl -Ls -o "${DOWNLOAD_DIR}/istio.tar.gz" "$ISTIO_RELEASE"
     tar -C "$DOWNLOAD_DIR" --strip-components=1 -xvpf "$DOWNLOAD_DIR/istio.tar.gz"
 fi
 
@@ -36,10 +36,6 @@ fi
 
 # Install Istio for openshift
 istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout ${hostNetArg:-}
-
-# Expose openshift route for istio
-# Not really needed, since we make our own DNS records to circumvent openshift-router
-oc -n istio-system expose svc/istio-ingressgateway --port=http2
 
 # Install gateway api
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -; }

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -8,6 +8,8 @@ pushd $thisdir > /dev/null 2>&1
 DOWNLOAD_DIR="/tmp/istio-download"
 mkdir -p "$DOWNLOAD_DIR"
 
+: "${ISTIO_HOST_NETWORKING:=""}"
+
 # Must do this for openshift to allow istio to work
 oc create namespace istio-system --dry-run=client -o yaml | oc apply -f -
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
@@ -28,7 +30,6 @@ fi
 
 PATH="$DOWNLOAD_DIR/bin:$PATH"
 
-hostNetArg=""
 if [[ "$ISTIO_HOST_NETWORKING" == "true" ]]; then
   hostNetArg="-f $thisdir/../yaml/hostnet-overlay.yaml"
 fi

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -1,34 +1,38 @@
 #!/bin/bash
 
+set -eu
+
+thisdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pushd $thisdir > /dev/null 2>&1
+
 DOWNLOAD_DIR="/tmp/istio-download"
-rm -rf ${DOWNLOAD_DIR}
-mkdir -p ${DOWNLOAD_DIR}
+mkdir -p "$DOWNLOAD_DIR"
 
 # Must do this for openshift to allow istio to work
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
 oc adm policy add-scc-to-user privileged -n istio-system -z istio-ingressgateway-service-account
 
-# Download istio again
-cd ${DOWNLOAD_DIR}
-curl -L https://istio.io/downloadIstio | sh -
-if [[ $? -ne 0 ]]; then
-  echo "ERROR: Failed to download istio"
-  exit 1
-fi
-cd - > /dev/null
+: ${ISTIO_RELEASE:="https://github.com/istio/istio/releases/download/1.14.2/istio-1.14.2-linux-amd64.tar.gz"}
 
-istioctl=$(find ${DOWNLOAD_DIR} -iname "istioctl" | head -1)
-if [[ ! -f "$istioctl" ]]; then
-  echo "ERROR: can't find istioctl at: $istioctl"
-  exit 1
+if [[ ! -x "$DOWNLOAD_DIR/bin/istioctl" ]]; then
+    echo "Downloading and extracting $ISTIO_RELEASE"
+    curl -Ls -o istio.tar.gz --output-dir "$DOWNLOAD_DIR" "$ISTIO_RELEASE"
+    tar -C "$DOWNLOAD_DIR" --strip-components=1 -xvpf "$DOWNLOAD_DIR/istio.tar.gz"
 fi
+
+if [[ ! -x "$DOWNLOAD_DIR/bin/istioctl" ]]; then
+    echo "istioctl not found in $DOWNLOAD_DIR/bin";
+    exit 1
+fi
+
+PATH="$DOWNLOAD_DIR/bin:$PATH"
 
 if [[ "$ISTIO_HOST_NETWORKING" == "true" ]]; then
-  hostNetArg="-f ../yaml/hostnet-overlay.yaml"
+  hostNetArg="-f $thisdir/../yaml/hostnet-overlay.yaml"
 fi
 
 # Install Istio for openshift
-$istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout $hostNetArg
+istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout $hostNetArg
 
 # Expose openshift route for istio
 # Not really needed, since we make our own DNS records to circumvent openshift-router

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -9,6 +9,7 @@ DOWNLOAD_DIR="/tmp/istio-download"
 mkdir -p "$DOWNLOAD_DIR"
 
 # Must do this for openshift to allow istio to work
+oc create namespace istio-system --dry-run=client -o yaml | oc apply -f -
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
 oc adm policy add-scc-to-user privileged -n istio-system -z istio-ingressgateway-service-account
 

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -3,7 +3,7 @@
 set -eu
 
 thisdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-pushd $thisdir > /dev/null 2>&1
+pushd "$thisdir" > /dev/null 2>&1
 
 DOWNLOAD_DIR="/tmp/istio-download"
 mkdir -p "$DOWNLOAD_DIR"
@@ -15,7 +15,7 @@ oc create namespace istio-system --dry-run=client -o yaml | oc apply -f -
 oc adm policy add-scc-to-group anyuid system:serviceaccounts:istio-system
 oc adm policy add-scc-to-user privileged -n istio-system -z istio-ingressgateway-service-account
 
-: ${ISTIO_RELEASE:="https://github.com/istio/istio/releases/download/1.14.2/istio-1.14.2-linux-amd64.tar.gz"}
+: "${ISTIO_RELEASE:=https://github.com/istio/istio/releases/download/1.14.2/istio-1.14.2-linux-amd64.tar.gz}"
 
 if [[ ! -x "$DOWNLOAD_DIR/bin/istioctl" ]]; then
     echo "Downloading and extracting $ISTIO_RELEASE"
@@ -35,7 +35,7 @@ if [[ "$ISTIO_HOST_NETWORKING" == "true" ]]; then
 fi
 
 # Install Istio for openshift
-istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout $hostNetArg
+istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout ${hostNetArg:-}
 
 # Expose openshift route for istio
 # Not really needed, since we make our own DNS records to circumvent openshift-router

--- a/helper-scripts/install-istio-gwapi.sh
+++ b/helper-scripts/install-istio-gwapi.sh
@@ -28,6 +28,7 @@ fi
 
 PATH="$DOWNLOAD_DIR/bin:$PATH"
 
+hostNetArg=""
 if [[ "$ISTIO_HOST_NETWORKING" == "true" ]]; then
   hostNetArg="-f $thisdir/../yaml/hostnet-overlay.yaml"
 fi

--- a/helper-scripts/patch-envoy-configuration.sh
+++ b/helper-scripts/patch-envoy-configuration.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 

--- a/setup-itsio-example.sh
+++ b/setup-itsio-example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu
 

--- a/setup-itsio-example.sh
+++ b/setup-itsio-example.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
+set -eu
+
 HELPER="./helper-scripts"
 
 # Install Istio and Gateway API
-${HELPER}/install-istio-gwapi.sh $@
+${HELPER}/install-istio-gwapi.sh "$@"
 
 # Clear certs for new installation
 rm -rf /tmp/istio-certs
 
 # Configure nginx examples
-${HELPER}/create-nginx-examples.sh $@
+${HELPER}/create-nginx-examples.sh "$@"
 
 if [[ "$ISTIO_BM" != "true" ]]; then
   # Convert the console route to istio ingress

--- a/test-all-routes.sh
+++ b/test-all-routes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#! /usr/bin/env bash
 
 hosts_gwapi="$(oc get httproute -n gwapi --no-headers -o custom-columns="route:.spec.hostnames[0]") $(oc get tlsroute -n gwapi --no-headers -o custom-columns="route:.spec.hostnames[0]")"
 hosts_istio="$(oc get VirtualService -n istioapi --no-headers -o custom-columns="route:.spec.hosts[0]")"

--- a/uninstall-istio.sh
+++ b/uninstall-istio.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if ! command -v istioctl &> /dev/null; then
+    echo "istioctl not found"
+    exit 2
+fi
+
+istioctl x uninstall --skip-confirmation --purge
+oc get namespace istio-system &> /dev/null && oc delete namespace istio-system

--- a/uninstall-istio.sh
+++ b/uninstall-istio.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+DOWNLOAD_DIR="/tmp/istio-download"
+PATH="$DOWNLOAD_DIR/bin:$PATH"
+
 if ! command -v istioctl &> /dev/null; then
     echo "istioctl not found"
     exit 2


### PR DESCRIPTION
From frobware's PR https://github.com/gcs278/istio-gateway-api-demo/pull/1
I couldn't modify his PR, so I'm making my own and merging with updates.

- install: avoid repeated istio downloads
- setup-istio-example.sh: quote command line args to invoked scripts
- setup-istio-example.sh: create istio-system namespace
- Add uninstall script
- Change shebang to: "/usr/bin/env bash"
- install-istio-gwapi.sh: Initialise hostNetArg
- Make istio-ingressgateway-service-account creation idempotent
- Initialise GW_MANUAL_DEPLOYMENT if unset
- Initialise ISTIO_BM if unset
- Initialise ISTIO_HOST_NETWORKING if unset
- install: fix some quoting issues