### PR TITLE
Openshift Istio via Service Mesh Operator:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 This is a project to demo Istio Gateway with Gateway API in Openshift. It is experimental and still rapidly changing.
 ### What does it do?
  - Istio will be installed (control plane, CRDs, etc..)
+   - See `ISTIO_OSSM` for details on how it's installed.
  - Gateway API CRDs will be installed
  - Two additional Ingress Paths will be configured:
-   1. Ingress via Gateway API with Istio
+   1. Ingress via Gateway API with Istio (if `ISTIO_API_DEMO` is true)
      - GWAPI Ingress objects and Envoy Proxy Deployments will exist in `gwapi` namespace
    2. Ingress via Istio API directly 
      - Istio API Ingress objects will exist in `istioapi` and associated Envoy Proxy Deployments will exist in `istio-system`
  - DNS Records are configured for the separate Ingresses:
    - `*.gwapi.<DOMAIN>` for GWAPI Istio Gateway Ingress
-   - `*.istio.<DOMAIN>` for Istio API Gateway Ingress
- - The console route will be converted from Route Ingress to Istio API Ingress
- - The control plane (istiod) will exists in `istio-system`
+   - `*.istio.<DOMAIN>` for Istio API Gateway Ingress (if `ISTIO_API_DEMO` is true)
+ - The console route will be converted from Route Ingress to Istio API Ingress (if `ISTIO_CONVERT_CONSOLE` is true)
+ - The control plane (istiod) will exists in `istio-system` if `ISTIO_OSSM` is false, otherwise it will exists in `gwapi` if `ISTIO_OSSM` is true
 
 # How to run Istio Demo:
 **Warning:** Do not run this demo in a production environment. It is EXPERIMENTAL.
@@ -23,15 +24,20 @@ This is a project to demo Istio Gateway with Gateway API in Openshift. It is exp
 Istio Ingress should now be operational with your cluster
 
 # Env Variables:
-- **ISTIO_HOST_NETWORKING**: If true, then Istio API will use host networking
-- **GW_MANUAL_DEPLOYMENT**: If true, then a single deployment will be created by these scrpits instead of allowing istiod to auto create it. This changes the architecture from one-to-one gateway to deployment to many-to-one gateways to our manual deployment. This is more aligned with openshift-router architecture.
-- **GW_HOST_NETWORKING**: If true, then Gateway API implementation will use host networking. Requires `GW_MANUAL_DEPLOYMENT` to be true
-- **ISTIO_BM**: If true, then setup will use baremetal configurations.
-- **ISTIO_CONVERT_CONSOLE**: If true, then scripts will convert the console route to Istio Gateway using Istio API.
+| Variable              | Description     | Default               |
+|-----------------------|-----------------|-------------------|
+| `ISTIO_API_DEMO`        | Scripts will also create a demo with Istio API Objects (not Gateway API). | `false` |
+| `ISTIO_HOST_NETWORKING` | Istio API will use host networking. Requires `ISTIO_API_DEMO` to be true. | `false` |
+| `ISTIO_BM` | All setup will use baremetal configurations. | `false` |
+| `ISTIO_CONVERT_CONSOLE` | Sripts will convert the console route to Istio Gateway using Istio API. | `false` |
+| `ISTIO_OSSM` | Openshift Service Mesh will be installed and be utilized for the control plane instead of using `istioctl`. | `false` |
+| `ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT` | All Gateway API objects will use the default single Envoy Proxy created by OSSM's Istiod (istio-system/istio-ingressgateway). | `true` |
+| `GW_MANUAL_DEPLOYMENT` | A single Envoy Deployment will be created by these scripts instead of allowing istiod to auto create it. This changes the architecture from one-to-one gateway to deployment to many-to-one gateways to our manual deployment. | `false` |
+| `GW_HOST_NETWORKING`   | Gateway API implementation will use host networking. Requires `GW_MANUAL_DEPLOYMENT` to be true. | `false` |
 
 # Debugging Tools in `./debug-scripts`
 - `dump-envoy-config-istioapi.sh` & `dump-envoy-config-gwapi.sh`
   - Download the envoy configuration for each ingress
 - `open-envoy-webpage-istioapi.sh` & `open-envoy-webpage-gwapi.sh`
   - Open the envoy configuration webpage for each ingress
- GWAPI Ingress objects and Envoy deployemnts will exist in `gwapi` namespace
+ GWAPI Ingress objects and Envoy deployments will exist in `gwapi` namespace

--- a/helper-scripts/configure-service-mesh.sh
+++ b/helper-scripts/configure-service-mesh.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+set -ue
+thisdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+YAML_DIR=${thisdir}/../yaml
+NAMESPACE="gwapi"
+
+
+echo "Configuring Istiod control plane for Gateway API demo"
+for i in {1..30}; do
+  if oc apply -f ${YAML_DIR}/service-mesh-control-plane.yaml; then
+    break
+  else
+    echo "Atempt #${i}: Failed to apply ${YAML_DIR}/service-mesh-control-plane.yaml..trying again."
+    sleep 3
+  fi
+done
+
+echo "Waiting for istiod deployment to rollout"
+for i in {1..30}; do
+  if oc rollout status -w deployment -n $NAMESPACE istiod-istio-ingress; then
+   break
+  else
+    echo "Attempt #${i}: Waiting for istiod-istio-ingress to appear...trying again."
+    sleep 3
+  fi
+done
+
+echo "Waiting for istio-ingressgateway deployment to rollout"
+oc rollout status -w deployment -n $NAMESPACE istio-ingressgateway
+
+# Due to https://issues.redhat.com/browse/OSSM-1846, we manually patch the istiod deployment to allow Pilot to auto-create deployments/services for Gateway API (one per Gateway Object)
+# This just enables the feature, but you have ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT=true set, this doesn't matter
+# NOTE: Due to service mesh not supporting deployment template injection, auto-deployment creation won't even work
+oc -n $NAMESPACE patch deploy/istiod-istio-ingress --type=strategic --patch='{"spec":{"template":{"spec":{"containers":[{"name":"discovery","env":[{"name":"PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER","value":"true"}]}]}}}}'

--- a/helper-scripts/install-gwapi.sh
+++ b/helper-scripts/install-gwapi.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+set -eu
+
+# Install gateway api
+echo "Installing Gateway API CRDs"
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -; }

--- a/helper-scripts/install-istio.sh
+++ b/helper-scripts/install-istio.sh
@@ -34,8 +34,5 @@ if [[ "$ISTIO_HOST_NETWORKING" == "true" ]]; then
   hostNetArg="-f $thisdir/../yaml/hostnet-overlay.yaml"
 fi
 
-# Install Istio for openshift
+# Install Istio via istioctl for openshift
 istioctl install -y --set profile=openshift --set meshConfig.accessLogFile=/dev/stdout ${hostNetArg:-}
-
-# Install gateway api
-kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -; }

--- a/helper-scripts/install-service-mesh-operator.sh
+++ b/helper-scripts/install-service-mesh-operator.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+set -ue
+thisdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+YAML_DIR=${thisdir}/../yaml
+
+echo "Installing Openshift Service Mesh Operator"
+oc apply -f ${YAML_DIR}/service-mesh-installation.yaml
+
+while ! oc get deployment -n openshift-operators istio-operator &> /dev/null; do
+  echo "Waiting for the istio-operator deployment to appear in openshift-operators namespace (this can take a long time)"
+  sleep 5
+done
+
+echo "Waiting for istio-operator deployment to rollout"
+oc rollout status -w deployment -n openshift-operators istio-operator
+
+# Uncomment if we decide to install Jaeger
+#while ! oc get deployment -n openshift-distributed-tracing jaeger-operator &> /dev/null; do
+#  echo "Waiting for the jaeger-operator deployment to appear in openshift-distributed-tracing namespace"
+#  sleep 5
+#done
+
+#echo "Waiting for jaeger-operator deployment to rollout"
+#oc rollout status -w deployment -n openshift-distributed-tracing jaeger-operator

--- a/setup-itsio-example.sh
+++ b/setup-itsio-example.sh
@@ -2,10 +2,64 @@
 
 set -eu
 
+# ENV Defaults
+set -a
+: "${ISTIO_API_DEMO:=false}"
+: "${ISTIO_HOST_NETWORKING:=false}"
+: "${ISTIO_BM:=false}"
+: "${ISTIO_CONVERT_CONSOLE:=false}"
+: "${ISTIO_OSSM:=false}"
+: "${ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT:=true}"
+: "${GW_MANUAL_DEPLOYMENT:=false}"
+: "${GW_HOST_NETWORKING:=false}"
+set +a
+
+echo "Environment Variables:"
+for var in $(compgen -v); do
+  if echo $var | grep -q 'ISTIO_\|GW_'; then
+    echo " --> ${var}=${!var}"
+  fi
+done
+
+# Validation
+if [[ "${GW_HOST_NETWORKING}" == "true" ]] && [[ "${GW_MANUAL_DEPLOYMENT}" == "false" ]]; then
+  echo "ERROR: If GW_HOST_NETWORKING=true then you must use GW_MANUAL_DEPLOYMENT=true"
+  echo "       I haven't figured out a way for the GWAPI Auto Deployments to use hostports/hostnetworking"
+  exit 1
+fi
+if [[ "${GW_MANUAL_DEPLOYMENT}" == "true" ]] && [[ "${ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT}" == "true" ]]; then
+  echo "ERROR: If GW_MANUAL_DEPLOYMENT=true then you must use ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT=false"
+  echo "       You can use the default OSSM Envoy Deployment and also use our manual gateway envoy deployment at the same time."
+  exit 1
+fi
+if [[ "${ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT}" != "true" ]]; then
+  echo "ERROR: ISTIO_OSSM_USE_DEFAULT_ENVOY_DEPLOYMENT must be true"
+  echo "       OSSM currently doesn't support Deployment Template injection, so auto-deployments won't work"
+  exit 1
+fi
+if [[ "${ISTIO_HOST_NETWORKING}" == "true" ]] && [[ "${ISTIO_API_DEMO}" == "false" ]]; then
+  echo "ERROR: If ISTIO_HOST_NETWORKING is true, then you must set ISTIO_API_DEMO to true"
+  exit 1
+fi
+if [[ "${ISTIO_CONVERT_CONSOLE}" == "true" ]] && [[ "${ISTIO_API_DEMO}" == "false" ]]; then
+  echo "ERROR: If ISTIO_CONVERT_CONSOLE is true, then you must set ISTIO_API_DEMO to true"
+  exit 1
+fi
+
+read -p "Press enter to continue the installation"
+
 HELPER="./helper-scripts"
 
-# Install Istio and Gateway API
-${HELPER}/install-istio-gwapi.sh "$@"
+# Install Istio via istioctl
+if [[ "${ISTIO_OSSM=}" == "true" ]]; then
+  ${HELPER}/install-service-mesh-operator.sh
+  ${HELPER}/configure-service-mesh.sh
+else
+  ${HELPER}/install-istio.sh
+fi
+
+# Install GW API CRDs
+${HELPER}/install-gwapi.sh
 
 # Clear certs for new installation
 rm -rf /tmp/istio-certs

--- a/yaml/service-mesh-control-plane.yaml
+++ b/yaml/service-mesh-control-plane.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gwapi
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: istio-ingress
+  namespace: gwapi
+spec:
+  tracing:
+    type: None
+  security:
+    manageNetworkPolicy: false
+  policy:
+    type: Istiod
+  gateways:
+    ingress:
+      service:
+        type: LoadBalancer
+      ingress: true
+      enabled: true
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+    prometheus:
+      enabled: false
+    jaeger:
+      name: jaeger
+      install: {}
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            PILOT_ENABLE_GATEWAY_API: "true"
+            PILOT_ENABLE_GATEWAY_API_STATUS: "true"
+            # NOTE: Enabling this breaks OSSM! See: https://issues.redhat.com/browse/OSSM-1846
+            #PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: "true"
+  version: v2.2
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: gwapi
+spec:
+  controlPlaneRef:
+    name: istio-ingress
+    namespace: gwapi
+  members:
+  - gwapi
+---
+# This due to bug about PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER so we can manually enable deployment creation
+# This can be removed when https://issues.redhat.com/browse/OSSM-1846 is fixed
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: serviceaccounts-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: istiod-istio-ingress
+  namespace: gwapi
+

--- a/yaml/service-mesh-installation.yaml
+++ b/yaml/service-mesh-installation.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  #startingCSV: servicemeshoperator.v2.2.1


### PR DESCRIPTION
- Added ISTIO_OSSM Env for installing Openshift Istio Service Mesh Operator and utilizing it for the demo
- Limited to only using the default Envoy Deployment (istio-ingressgateway)
- Limited to putting the Control Plane in the same namespace as our Gateway object (gwapi)